### PR TITLE
wrap python sdk from go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+kcore_wrap.*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sdk-cpp"]
+	path = sdk-cpp
+	url = https://github.com/kuzzleio/sdk-cpp

--- a/Makefile
+++ b/Makefile
@@ -67,14 +67,7 @@ python: CC = $(CPP)
 python: CFLAGS = -fPIC
 python: makedir make_c_sdk remove_so swig $(OBJS) make_lib
 	cp setup.py $(OUTDIR)
-	#mv kcore_wrap.* $(OUTDIR)
 	python3 $(OUTDIR)/setup.py build_ext -I.$(PATHSEP)sdk-cpp$(PATHSEP)include -I.$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP) -I.$(PATHSEP)sdk-cpp$(PATHSEP)src -I.$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)build$(PATHSEP) -l kuzzlesdk -b $(OUTDIR) -t $(OUTDIR)/tmp
-	# cp $(ROOT_DIR)templates/python/*.py $(OUTDIR)
-	# cp $(ROOT_DIR)$(SRCS) $(OUTDIR)/
-	# cp $(ROOT_DIR)kcore_wrap.h $(OUTDIR)/
-	# python3 $(OUTDIR)/setup.py build_ext -I $(HEADERSDIR):$(CPPDIR):$(OUTDIR):$(GOTARGETDIR):$(OUTDIR)/templates/python -L $(OUTDIR):$(GOTARGETDIR) -R $(GOTARGETDIR) -l kuzzlesdk  -b $(OUTDIR) -t $(OUTDIR)/tmp
-	# cp -p $(GOTARGET) $(OUTDIR)
-	# cp -p $(GOTARGETSO) $(OUTDIR)
 
 clean:
 	cd sdk-cpp && $(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,83 @@
+VERSION = 0.0.1
+
+ROOT_DIR = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+ifeq ($(OS),Windows_NT)
+	GOROOT ?= C:/Go
+	GOCC ?= $(GOROOT)bin\go
+	SEP = \\
+	RM = del /Q /F /S
+	RRM = rmdir /S /Q
+	MV = rename
+	CMDSEP = &
+	ROOT_DIR_CLEAN = $(subst /,\,$(ROOT_DIR))
+	LIB_PREFIX =
+else
+	GOROOT ?= /usr/local/go
+	GOCC ?= $(GOROOT)/bin/go
+	SEP = /
+	RM = rm -f
+	RRM = rm -f -r
+	MV = mv -f
+	CMDSEP = ;
+	ROOT_DIR_CLEAN = $(ROOT_DIR)
+	LIB_PREFIX = lib
+endif
+
+PATHSEP = $(strip $(SEP))
+JAVA_HOME ?= /usr/local
+ROOTOUTDIR = $(ROOT_DIR)/build
+SWIG = swig
+
+CXXFLAGS = -g -fPIC -std=c++11 -I.$(PATHSEP)sdk-cpp$(PATHSEP)include -I.$(PATHSEP)sdk-cpp$(PATHSEP)src -I.$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP) -I.$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)build$(PATHSEP) -L.$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)build
+LDFLAGS = -lkuzzlesdk
+
+PYTHON_INCLUDE_DIR ?= `pkg-config --cflags python3`
+PYTHONINCLUDE = $(PYTHON_INCLUDE_DIR)
+
+SRCS = kcore_wrap.cxx
+OBJS = $(SRCS:.cxx=.o)
+
+all: python
+
+kcore_wrap.o: kcore_wrap.cxx
+	$(CXX) -c $< -o $@ $(CXXFLAGS) $(LDFLAGS) $(PYTHONINCLUDE)
+
+makedir:
+ifeq ($(OS),Windows_NT)
+	@if not exist $(subst /,\,$(ROOTOUTDIR)) mkdir $(subst /,\,$(ROOTOUTDIR))
+else
+	mkdir -p $(ROOTOUTDIR)
+endif
+
+make_c_sdk:
+	cd sdk-cpp/sdk-c && $(MAKE)
+
+swig:
+	$(SWIG) -Wall -c++ -python -py3 -outdir $(OUTDIR) -o $(SRCS) -I.$(PATHSEP)sdk-cpp$(PATHSEP)include -I.$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP) -I.$(PATHSEP)sdk-cpp$(PATHSEP)src -I.$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)build$(PATHSEP) $(PYTHONINCLUDE) swig/core.i
+
+make_lib:
+	$(CXX) -shared kcore_wrap.o -o $(OUTDIR)$(SEP)_kuzzlesdk.so $(CXXFLAGS) $(LDFLAGS) $(PYTHONINCLUDE)
+
+remove_so:
+	rm -rf .$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)build$(PATHSEP)*.so*
+
+python: LANGINCLUDE = $(PYTHONINCLUDE)
+python: OUTDIR = $(ROOTOUTDIR)
+python: CC = $(CPP)
+python: CFLAGS = -fPIC
+python: makedir make_c_sdk remove_so swig $(OBJS) make_lib
+	cp setup.py $(OUTDIR)
+	#mv kcore_wrap.* $(OUTDIR)
+	python3 $(OUTDIR)/setup.py build_ext -I.$(PATHSEP)sdk-cpp$(PATHSEP)include -I.$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP) -I.$(PATHSEP)sdk-cpp$(PATHSEP)src -I.$(PATHSEP)sdk-cpp$(PATHSEP)sdk-c$(PATHSEP)build$(PATHSEP) -l kuzzlesdk -b $(OUTDIR) -t $(OUTDIR)/tmp
+	# cp $(ROOT_DIR)templates/python/*.py $(OUTDIR)
+	# cp $(ROOT_DIR)$(SRCS) $(OUTDIR)/
+	# cp $(ROOT_DIR)kcore_wrap.h $(OUTDIR)/
+	# python3 $(OUTDIR)/setup.py build_ext -I $(HEADERSDIR):$(CPPDIR):$(OUTDIR):$(GOTARGETDIR):$(OUTDIR)/templates/python -L $(OUTDIR):$(GOTARGETDIR) -R $(GOTARGETDIR) -l kuzzlesdk  -b $(OUTDIR) -t $(OUTDIR)/tmp
+	# cp -p $(GOTARGET) $(OUTDIR)
+	# cp -p $(GOTARGETSO) $(OUTDIR)
+
+clean:
+	cd sdk-cpp && $(MAKE) clean
+	rm -rf build
+
+.PHONY: all clean swig python remove_so make_lib make_c_sdk makedir

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Python SDK implements the websocket protocol.
 Execute the following snippet to clone the GIT repository, and build the SDK. It will then be available in the "build/" directory
 
 ```sh
-git clone --recursive git@github.com:kuzzleio/sdk-python.git
+git clone --recursive git@github.com:kuzzleio/sdk-python3.git
 git submodule update --init --recursive
 cd sdk-python
 make

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Execute the following snippet to clone the GIT repository, and build the SDK. It
 ```sh
 git clone --recursive git@github.com:kuzzleio/sdk-python3.git
 git submodule update --init --recursive
-cd sdk-python
+cd sdk-python3
 make
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+Official Kuzzle Python SDK - ALPHA VERSION
+======
+
+## About Kuzzle
+
+A backend software, self-hostable and ready to use to power modern apps.
+
+You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuzzle)
+
+## SDK Documentation
+
+The complete SDK documentation is available [here](http://docs.kuzzle.io/sdk-reference/)
+
+## Protocol used
+
+The Python SDK implements the websocket protocol.
+
+### Build
+
+Execute the following snippet to clone the GIT repository, and build the SDK. It will then be available in the "build/" directory
+
+```sh
+git clone --recursive git@github.com:kuzzleio/sdk-python.git
+git submodule update --init --recursive
+cd sdk-python
+make
+```
+

--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,9 @@ setup.py file for SWIG example
 import os
 from distutils.core import setup, Extension
 
-# cwd = os.path.dirname(os.path.realpath(__file__))
-# kuzzle_module = Extension('kuzzlesdk',
-#                            sources=[ cwd + '/kcore_wrap.cxx' ],
-#                            swig_opts=['-c++', '-py3']
-#                            )
-
 setup (name = 'kcore',
        version = '0.0.1',
        author      = "Kuzzle",
        description = """Kuzzle sdk""",
-      #  ext_modules = ["kuzzlesdk"],
        py_modules = ["kcore"],
        )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+"""
+setup.py file for SWIG example
+"""
+
+import os
+from distutils.core import setup, Extension
+
+# cwd = os.path.dirname(os.path.realpath(__file__))
+# kuzzle_module = Extension('kuzzlesdk',
+#                            sources=[ cwd + '/kcore_wrap.cxx' ],
+#                            swig_opts=['-c++', '-py3']
+#                            )
+
+setup (name = 'kcore',
+       version = '0.0.1',
+       author      = "Kuzzle",
+       description = """Kuzzle sdk""",
+      #  ext_modules = ["kuzzlesdk"],
+       py_modules = ["kcore"],
+       )

--- a/swig/core.i
+++ b/swig/core.i
@@ -1,0 +1,69 @@
+%rename(TokenValidity) token_validity;
+%rename(AckResponse) ack_response;
+%rename(queueTTL) queue_ttl;
+%rename(Options, match="class") options;
+%rename(QueryOptions) query_options;
+%rename(JsonObject) json_object;
+%rename(JsonResult) json_result;
+%rename(LoginResult) login_result;
+%rename(BoolResult) bool_result;
+%rename(Statistics) statistics;
+%rename(AllStatisticsResult) all_statistics_result;
+%rename(StatisticsResult) statistics_result;
+%rename(CollectionsList) collection_entry;
+%rename(CollectionsListResult) collection_entry_result;
+%rename(StringArrayResult) string_array_result;
+%rename(KuzzleResponse) kuzzle_response;
+%rename(KuzzleRequest) kuzzle_request;
+%rename(ShardsResult) shards_result;
+%rename(DateResult) date_result;
+%rename(UserData) user_data;
+%rename(User, match="class") user;
+%rename(RoomOptions) room_options;
+%rename(SearchFilters) search_filters;
+%rename(SearchResult) search_result;
+%rename(NotificationResult) notification_result;
+%rename(NotificationContent) notification_content;
+%rename(SubscribeToSelf) subscribe_to_self;
+
+%ignore *::error;
+%ignore *::status;
+%ignore *::stack;
+
+%feature("director") NotificationListener;
+%feature("director") EventListener;
+%feature("director") SubscribeListener;
+
+%{
+#include "kuzzle.cpp"
+#include "collection.cpp"
+#include "auth.cpp"
+#include "index.cpp"
+#include "server.cpp"
+#include "document.cpp"
+#include "realtime.cpp"
+
+#define SWIG_FILE_WITH_INIT
+%}
+
+%include "stl.i"
+%include "kcore.i"
+
+%extend options {
+    options() {
+        options *o = kuzzle_new_options();
+        return o;
+    }
+
+    ~options() {
+        free($self);
+    }
+}
+
+%include "kuzzle.cpp"
+%include "collection.cpp"
+%include "document.cpp"
+%include "realtime.cpp"
+%include "auth.cpp"
+%include "index.cpp"
+%include "server.cpp"

--- a/swig/kcore.i
+++ b/swig/kcore.i
@@ -1,0 +1,30 @@
+/* File : kcore.i */
+
+%module(directors="1") kuzzlesdk
+%{
+#include "exceptions.hpp"
+#include "event_emitter.hpp"
+#include "kuzzle.hpp"
+#include "collection.hpp"
+#include "index.hpp"
+#include "server.hpp"
+#include "document.hpp"
+#include "realtime.hpp"
+#include "auth.hpp"
+#include <assert.h>
+%}
+
+%define _Complex
+%enddef
+
+%include "kuzzlesdk.h"
+%include "kuzzle.h"
+%include "exceptions.hpp"
+%include "event_emitter.hpp"
+%include "kuzzle.hpp"
+%include "collection.hpp"
+%include "index.hpp"
+%include "server.hpp"
+%include "document.hpp"
+%include "realtime.hpp"
+%include "auth.hpp"


### PR DESCRIPTION
## What does this PR do ?

Wrap python SDK from go

### How should this be manually tested?

```sh
git clone --recursive git@github.com:kuzzleio/sdk-python3.git
git submodule update --init --recursive
cd sdk-python3
make
```

You can then write a script in the build directory like
```python
import kuzzlesdk

k = kuzzlesdk.Kuzzle("localhost")
# kuzzlesdk.Server.now()

k.connect()

s = kuzzlesdk.Server(k)
print(s.now())
```
and try it with python3 test.py

(Yes the Server class should be in the Kuzzle object but I think there is things to do in swig to make it happen, this is an ALPHA version and more work has to be done)